### PR TITLE
Warn users that service will be ready on Wednesday

### DIFF
--- a/src/client/templates/all-teams-template.html
+++ b/src/client/templates/all-teams-template.html
@@ -31,6 +31,7 @@
 
     <body>
         <div>
+            <h2 style="padding-left: 110px;">Ce site sera opérationnel le mercredi 9 mai au matin</h2>
             <h2>Equipes enregistrées:</h2>
             <ul>
                 <span>créer une nouvelle équipe</span></br>


### PR DESCRIPTION


Adds a warning message on the main page to mention that the website will be ready on Wednesday morning only.

On laptops:
<img width="1272" alt="screen shot 2018-05-06 at 9 14 49 am" src="https://user-images.githubusercontent.com/1532259/39670868-2cabf11a-510e-11e8-913b-cfcd794c46f4.png">

On mobiles:

<img width="781" alt="screen shot 2018-05-06 at 9 14 56 am" src="https://user-images.githubusercontent.com/1532259/39670869-31b56f2e-510e-11e8-97de-c7a76a32235b.png">
